### PR TITLE
Forward request from custom handler to localserver

### DIFF
--- a/ee/customprotocol/custom_protocol_handler_darwin_test.go
+++ b/ee/customprotocol/custom_protocol_handler_darwin_test.go
@@ -1,0 +1,53 @@
+//go:build darwin
+// +build darwin
+
+package customprotocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractRequestPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		testCaseName  string
+		requestUrl    string
+		expectedPath  string
+		expectedError bool
+	}{
+		{
+			testCaseName:  "valid request",
+			requestUrl:    "kolide://local/v3/cmd?box=abcd",
+			expectedPath:  "/v3/cmd?box=abcd",
+			expectedError: false,
+		},
+		{
+			testCaseName:  "valid request, no query",
+			requestUrl:    "kolide://local/v4/cmd",
+			expectedPath:  "/v4/cmd",
+			expectedError: false,
+		},
+		{
+			testCaseName:  "invalid request",
+			requestUrl:    string(rune(0x7f)), // invalid control character in URL
+			expectedPath:  "",
+			expectedError: true,
+		},
+	} {
+		tt := tt
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			t.Parallel()
+
+			reqPath, err := extractRequestPath(tt.requestUrl)
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedPath, reqPath)
+			}
+		})
+	}
+}

--- a/ee/localserver/server.go
+++ b/ee/localserver/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Special Kolide Ports
-var portList = []int{
+var PortList = []int{
 	12519,
 	40978,
 	52115,
@@ -324,7 +324,7 @@ func (ls *localServer) Interrupt(_ error) {
 func (ls *localServer) startListener() (net.Listener, error) {
 	ctx := context.TODO()
 
-	for _, p := range portList {
+	for _, p := range PortList {
 		ls.slogger.Log(ctx, slog.LevelDebug,
 			"trying port",
 			"port", p,


### PR DESCRIPTION
Builds on https://github.com/kolide/launcher/pull/1707 to handle the incoming requests by forwarding them to localserver.